### PR TITLE
drhuffman12/update_dependencies_crystal_0_29_0_ameba_0_10_0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,11 +7,11 @@ description: |
 authors:
   - Iñaki Lanusse <inakilanusse@gmail.com>
 
-crystal: 0.27.2
+crystal: 0.29.0
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: 0.9.0
+    version: 0.10.0


### PR DESCRIPTION
Update to Crystal 0.29.0 and Ameba 0.10.0.

This fixes https://github.com/ilanusse/praetorian/issues/3 . (See https://travis-ci.com/drhuffman12/praetorian/builds/115530509 )
